### PR TITLE
reversed https://github.com/CatherineWong/laps_dreamcoder/pull/1

### DIFF
--- a/program.py
+++ b/program.py
@@ -1250,12 +1250,6 @@ class EtaLongVisitor(object):
         else:
             assert False, "Not in beta long form: %s" % e
 
-        for i,x in enumerate(xs):
-            self.context.unify(
-                ft.functionArguments()[i],
-                x.infer().instantiateMutable(self.context))
-            ft = ft.applyMutable(self.context)
-
         self.context.unify(request, ft.returns())
         ft = ft.applyMutable(self.context)
 


### PR DESCRIPTION
This PR reverses https://github.com/CatherineWong/laps_dreamcoder/pull/1

**TL;DR this should have no effect on anything but is a good cleanup change to make. The old PR was replacing one crash (during eta long) with a different crash (during likelihood computation) and neither of these crashes happen these days anyways thanks to stitch being better. But we should make this change please!**

That old PR made `EtaLongVisitor` slightly more permissive as follows: if you have a polymorphic function of type `t0 -> t0` you would expect it to take 1 argument. However if you have `t0 = (int -> int)` then this becomes `(int -> int) -> int -> int` and thus it can take 2 arguments (an `int->int` and an `int`). https://github.com/CatherineWong/laps_dreamcoder/pull/1 allows for this, while previously it would cause an eta long crash.

However, that change wasn't actually useful because it would just result in a crash downstream when it comes time to calculate likelihoods - since likelihood computation will crash when the 1-argument function is passed 2 arguments. And in fact this is intended behavior because top-down search actually can only generate the version that passes a single argument it, so the 2-argument version isn't in the support. Therefore that old PR really wasn't well-founded, though it also didn't do any harm since it really just replaced eta-long crashes with likelihood crashes.

Nowadays stitch returns things already in eta long form (if the eta_long flag is passed), and in fact we've seen that EtaLongVisitor is a no-op on the results of stitch on tons of test dreamcoder data. Also stitch abstractions are always rooted at non-function-type nodes and have a fixed number of arguments so even if `t0->t0` is the type of an abstraction, all of its usages will take only one argument.

